### PR TITLE
fix: re-creating experiment

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,7 @@ aiohttp_cors
 potion_client>=2.5.1
 requests
 codecov
-gnomic
+gnomic==0.7.0
 gunicorn
 pytest-cov
 pandas


### PR DESCRIPTION
Fix bug in creating new experiment which lead to always re-creating the
experiment. Fix bug in searching for existing samples (only used sample
names which are not unique alone).