### PR TITLE
Mount dev volume at /opt/upload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,7 @@ services:
     ports:
       - "${UPLOAD_PORT:-7000}:7000"
     volumes:
-      - ./:/source
+      - ./:/opt/upload
     environment:
       - PYTHONUNBUFFERED=1
       - PYTHONASYNCIODEBUG=1


### PR DESCRIPTION
The workdir for the image is located at this path, so the development volume should also be mounted here.