### PR TITLE
Add gunicorn development parameters for autoreload

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,6 +5,7 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+    command: "-w 2 -b 0.0.0.0:7000 -t 150 -k aiohttp.worker.GunicornWebWorker --reload upload.app:app"
     ports:
       - "${UPLOAD_PORT:-7000}:7000"
     volumes:


### PR DESCRIPTION
This ensures that the gunicorn server automatically reloads when loaded python modules change in development.