### PR TITLE
Add Sentry integration

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,4 @@ gunicorn
 pytest-cov
 pandas
 goodtables==1.0.0a16
+raven==6.4.0

--- a/upload/__init__.py
+++ b/upload/__init__.py
@@ -4,10 +4,22 @@ from potion_client import Client
 from potion_client.auth import HTTPBearerAuth
 import requests
 import numpy as np
+from raven import Client as RavenClient
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
 
 logger = logging.getLogger('upload')
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))  # Logspout captures logs from stdout if docker containers
 logger.setLevel(logging.DEBUG)
+
+# Configure Raven to capture warning logs
+raven_client = RavenClient(settings.Default.SENTRY_DSN)
+handler = SentryHandler(raven_client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)
 
 
 def iloop_client(api, token):

--- a/upload/app.py
+++ b/upload/app.py
@@ -18,6 +18,7 @@ from upload.settings import Default
 from upload.checks import (compound_name_unknown, medium_name_unknown, strain_alias_unknown,
                            reaction_id_unknown, protein_id_unknown, synonym_to_chebi_name, check_safe_partial,
                            medium_name_already_defined, iloop_cache)
+from upload.middleware import raven_middleware
 
 UPLOAD_TYPES = frozenset(['strains', 'media', 'fermentation', 'screen', 'fluxes', 'protein_abundances'])
 
@@ -160,7 +161,7 @@ ROUTE_CONFIG = [
     ('GET', '/upload/schema/{what}', schema),
 ]
 
-app = web.Application()
+app = web.Application(middlewares=[raven_middleware])
 # Configure default CORS settings.
 cors = aiohttp_cors.setup(app, defaults={
     "*": aiohttp_cors.ResourceOptions(

--- a/upload/middleware.py
+++ b/upload/middleware.py
@@ -1,18 +1,4 @@
-import logging
-
-from aiohttp import web
-from raven import Client
-from raven.conf import setup_logging
-from raven.handlers.logging import SentryHandler
-
-from . import settings
-
-
-# Configure Raven to capture warning logs
-client = Client(settings.Default.SENTRY_DSN)
-handler = SentryHandler(client)
-handler.setLevel(logging.WARNING)
-setup_logging(handler)
+from . import raven_client
 
 
 async def raven_middleware(app, handler):
@@ -21,6 +7,6 @@ async def raven_middleware(app, handler):
         try:
             return await handler(request)
         except Exception:
-            client.captureException()
+            raven_client.captureException()
             raise
     return middleware_handler

--- a/upload/middleware.py
+++ b/upload/middleware.py
@@ -1,0 +1,26 @@
+import logging
+
+from aiohttp import web
+from raven import Client
+from raven.conf import setup_logging
+from raven.handlers.logging import SentryHandler
+
+from . import settings
+
+
+# Configure Raven to capture warning logs
+client = Client(settings.Default.SENTRY_DSN)
+handler = SentryHandler(client)
+handler.setLevel(logging.WARNING)
+setup_logging(handler)
+
+
+async def raven_middleware(app, handler):
+    """aiohttp middleware which captures any uncaught exceptions to Sentry before re-raising"""
+    async def middleware_handler(request):
+        try:
+            return await handler(request)
+        except Exception:
+            client.captureException()
+            raise
+    return middleware_handler

--- a/upload/settings.py
+++ b/upload/settings.py
@@ -6,3 +6,4 @@ class Default(object):
     ILOOP_TOKEN = os.environ.get('ILOOP_TOKEN')
     ILOOP_BIOSUSTAIN = 'https://iloop.biosustain.dtu.dk/api'
     NOT_PUBLIC = {'NPC'}
+    SENTRY_DSN = os.environ.get('SENTRY_DSN', '')


### PR DESCRIPTION
Adds Raven to capture error events to Sentry

- aiohttp middleware logs uncaught exceptions, and re-raises
- log events of `warning` or higher level